### PR TITLE
Editor was showing up in production, this is fixed and there's now configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## 0.2.0
+
+### New features
+
+- Editor can now be turned off if needed on individual pages (see README for details)
+
+### Fixes
+
+- Editor displaying when protototype is hosted 
+
+## 0.1.0
+
+### New features
+
+- Created the first version of the in-browser editor

--- a/README.md
+++ b/README.md
@@ -28,6 +28,31 @@ Phase: Beta
 
 This is a beta product, we know that improvements need making and we'd like your feedback.
 
+Configuration
+---
+
+If you want to have the editor on some pages but not others you can turn the editor off for by adding this near the top of your page:
+
+```html
+<script>
+  window.XGOVUK = window.XGOVUK || {}
+  window.XGOVUK.editPrototypeInBrowser = window.XGOVUK.editPrototypeInBrowser || {}
+
+  window.XGOVUK.editPrototypeInBrowser.doNotEditThisPage = true
+</script>
+```
+
+Currently the editor shows when you're running on localhost but not on other domains, if you want it to work on different domains you can add them like this: 
+
+```html
+<script>
+  window.XGOVUK = window.XGOVUK || {}
+  window.XGOVUK.editPrototypeInBrowser = window.XGOVUK.editPrototypeInBrowser || {}
+
+  window.XGOVUK.editPrototypeInBrowser.allowedDomains = ['example.com', 'another-domain.net']
+</script>
+```
+
 Issues and feedback
 ---
 

--- a/assets/editor.js
+++ b/assets/editor.js
@@ -1,4 +1,21 @@
 (() => {
+  window.XGOVUK = window.XGOVUK || {}
+  window.XGOVUK.editPrototypeInBrowser = window.XGOVUK.editPrototypeInBrowser || {}
+
+  if (window.XGOVUK.editPrototypeInBrowser.doNotEditThisPage) {
+    return
+  }
+
+  if (!window.XGOVUK.editPrototypeInBrowser.allowedDomains) {
+    window.XGOVUK.editPrototypeInBrowser.allowedDomains = [
+      'localhost'
+    ]
+  }
+
+  if (!window.XGOVUK.editPrototypeInBrowser.allowedDomains.includes(window.location.hostname)) {
+    return
+  }
+
   const routesContext = '/plugin-routers/x-govuk/edit-prototype-in-browser'
 
   const $monacoLoader = document.createElement('script')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@x-govuk/edit-prototype-in-browser",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@x-govuk/edit-prototype-in-browser",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-govuk/edit-prototype-in-browser",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An in-browser editor for the govuk-prototype-kit",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
By default the editor now only shows up on `localhost`, but that's configurable.

I've also added configuration to turn it off for individual pages (which can be used in layouts etc. too to turn it off more widely)