### PR TITLE
No setup needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0
+
+### New features
+
+- The setup line is no longer needed, just install and it'll work
+
 ## 0.2.1
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -8,21 +8,6 @@ Requirements
 
 This works with the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/) v13.0.0 and above.
 
-Setup
----
-
-To enable the editor you need to install the package and add the router.  Open a terminal in your prototype's folder and run
-
-```shell
-npm install @x-govuk/edit-prototype-in-browser
-```
-
-Then go into your `app/routes.js` and add the following line:
-
-```javascript
-require('@x-govuk/edit-prototype-in-browser').addRoutes(require('govuk-prototype-kit').requests)
-```
-
 Phase: Beta
 ---
 

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "description": "An in-browser editor for the prototype kit, it needs one line of setup which can be found in the documentation and then you can edit pages without leaving the browser.",
+    "description": "An in-browser editor for the prototype kit, it allows you to edit pages without leaving the browser.",
     "urls": {
-      "documentation": "https://www.npmjs.com/package/@x-govuk/edit-prototype-in-browser/v/{{version}}#user-content-setup",
+      "documentation": "https://www.npmjs.com/package/@x-govuk/edit-prototype-in-browser/v/{{version}}#readme",
       "versionHistory": "https://github.com/x-govuk/edit-prototype-in-browser/blob/main/CHANGELOG.md"
     }
   },
@@ -11,5 +11,8 @@
   ],
   "scripts": [
     "/assets/editor.js"
+  ],
+  "nunjucksFilters": [
+    "/routes.js"
   ]
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,50 @@
-const routes = require('./routes')
+const path = require('path')
 
 module.exports = {
-  addRoutes: routes.addRoutes
+  addRoutes: () => {
+    const display = (lines) => {
+      const padding = 10
+      const longestLineLength = lines.map(line => line.length).sort((a, b) => { if (a > b) { return -1 } if (b > a) { return 1 } return 0 }).at(0) + padding
+      const consoleColumns = process.stdout.columns
+      const isTooLongToCentre = consoleColumns < longestLineLength
+      const separatorChar = '*'
+      let separator = ''
+      while (separator.length < (isTooLongToCentre ? 20 : longestLineLength)) {
+        if (separator.length > 0) {
+          separator += ' '
+        }
+        separator += separatorChar
+      }
+      console.log('')
+      console.log(separator)
+      lines.forEach(line => {
+        if (isTooLongToCentre) {
+          console.log(line)
+          return
+        }
+        const paddingSizeEachSide = Math.floor((separator.length - line.length) / 2)
+        let pad = ''
+        while (pad.length < paddingSizeEachSide) {
+          pad += ' '
+        }
+        console.log(`${pad}${line}${pad}`)
+      })
+      console.log(separator)
+      console.log('')
+    }
+    let fileName, lineNumber
+    try {
+      throw new Error()
+    } catch (e) {
+      try {
+        [fileName, lineNumber] = e.stack.split('\n')[2]?.split('(')[1]?.split(')')[0]?.replace(process.cwd() + path.sep, '').split(':')
+      } catch (e) {}
+    }
+    const output = ['You no longer to use need the `addRoutes` line.', 'This line used to be needed to enable the in-browser editor.']
+    if (fileName) {
+      output.push('')
+      output.push(`It looks like the line you need to remove is in ${fileName}` + (lineNumber ? ` on line ${lineNumber}.` : '.'))
+    }
+    display(output)
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@x-govuk/edit-prototype-in-browser",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@x-govuk/edit-prototype-in-browser",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-govuk/edit-prototype-in-browser",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "An in-browser editor for the govuk-prototype-kit",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An in-browser editor for the govuk-prototype-kit",
   "main": "index.js",
   "scripts": {
-    "test": "govuk-prototype-kit validate-plugin && standard"
+    "test": "govuk-prototype-kit validate-plugin && standard",
+    "lint:fix": "standard --fix"
   },
   "repository": {
     "type": "git",

--- a/routes.js
+++ b/routes.js
@@ -6,168 +6,163 @@ const projectDir = process.cwd()
 const packageDir = __dirname
 const contextPath = '/plugin-routers/x-govuk/edit-prototype-in-browser'
 
-function addRoutes (routesApi) {
-  const editorRouter = routesApi.setupRouter(contextPath)
+const routesApi = require('govuk-prototype-kit').requests
+const editorRouter = routesApi.setupRouter(contextPath)
 
-  editorRouter.get('/', (req, res) => {
-    res.send({})
-  })
+editorRouter.get('/', (req, res) => {
+  res.send({})
+})
 
-  function fileDescriptor (label, relativePath, type) {
-    return {
-      label,
-      path: relativePath,
-      type
-    }
+function fileDescriptor (label, relativePath, type) {
+  return {
+    label,
+    path: relativePath,
+    type
+  }
+}
+
+function withExtension (partialPath, extension) {
+  let output = partialPath
+
+  if (output.endsWith('.html')) {
+    output = output.substring(0, output.length - '.html'.length)
+  } else if (output.endsWith('.njk')) {
+    output = output.substring(0, output.length - '.njk'.length)
   }
 
-  function withExtension (partialPath, extension) {
-    let output = partialPath
+  output += `.${extension}`
 
-    if (output.endsWith('.html')) {
-      output = output.substring(0, output.length - '.html'.length)
-    } else if (output.endsWith('.njk')) {
-      output = output.substring(0, output.length - '.njk'.length)
-    }
+  return output
+}
 
-    output += `.${extension}`
+async function loadNunjucks (njkPath) {
+  const filePathsToTry = [
+    njkPath,
+    withExtension(njkPath, 'html'),
+    withExtension(njkPath, 'njk'),
+    `${njkPath}/index`,
+    withExtension(`${njkPath}/index`, 'html'),
+    withExtension(`${njkPath}/index`, 'njk')
+  ].map(x => path.join(projectDir, 'app', 'views', x))
 
-    return output
-  }
-
-  async function loadNunjucks (njkPath) {
-    const filePathsToTry = [
-      njkPath,
-      withExtension(njkPath, 'html'),
-      withExtension(njkPath, 'njk'),
-      `${njkPath}/index`,
-      withExtension(`${njkPath}/index`, 'html'),
-      withExtension(`${njkPath}/index`, 'njk')
-    ].map(x => path.join(projectDir, 'app', 'views', x))
-
-    while (filePathsToTry.length > 0) {
-      const filePath = filePathsToTry.shift()
-      try {
-        const isFile = (await fsp.lstat(filePath)).isFile()
-        if (isFile) {
-          return {
-            path: filePath,
-            src: await fsp.readFile(filePath, 'utf8')
-          }
-        }
-      } catch (e) {}
-    }
-  }
-
-  async function addIfFileExistsAndCanBeEdited (files, label, relativeOrAbsolutePath, type) {
-    const relativePath = relativeOrAbsolutePath.startsWith('/') || relativeOrAbsolutePath.substring(1, 3) === ':\\' ? path.relative(projectDir, relativeOrAbsolutePath) : relativeOrAbsolutePath
-    if (relativePath.startsWith('node_modules') || relativePath.startsWith('.tmp')) {
-      return
-    }
-    const pathToCheck = path.join(projectDir, relativePath)
-    if (await fse.exists(pathToCheck)) {
-      files.push(fileDescriptor(label, relativePath, type))
-    }
-  }
-
-  editorRouter.get('/files-behind-url', async (req, res) => {
-    const { url } = req.query
-    if (!url) {
-      res.status(400).send('No URL provided.')
-      return
-    }
-    const view = await loadNunjucks(url)
-    if (view) {
-      const files = []
-      await addIfFileExistsAndCanBeEdited(files, 'page', view.path, 'NUNJUCKS')
-      const layoutMatch = view.src.match(/\{\s*%\s+extends\s+"([^"]+)"\s*%\s*}/)
-      if (layoutMatch) {
-        const njk = await loadNunjucks(layoutMatch[1])
-        if (njk) {
-          await addIfFileExistsAndCanBeEdited(files, 'layout', njk.path, 'NUNJUCKS')
+  while (filePathsToTry.length > 0) {
+    const filePath = filePathsToTry.shift()
+    try {
+      const isFile = (await fsp.lstat(filePath)).isFile()
+      if (isFile) {
+        return {
+          path: filePath,
+          src: await fsp.readFile(filePath, 'utf8')
         }
       }
-      await addIfFileExistsAndCanBeEdited(files, 'config', 'app/config.json', 'JSON')
-      await addIfFileExistsAndCanBeEdited(files, 'javascript', 'app/assets/javascripts/application.js', 'JS')
-      await addIfFileExistsAndCanBeEdited(files, 'scss', 'app/assets/sass/application.scss', 'SCSS')
-      await addIfFileExistsAndCanBeEdited(files, 'scss settings', 'app/assets/sass/settings.scss', 'SCSS')
-
-      res.send({
-        success: true,
-        files
-      })
-    } else {
-      res.send({
-        success: false,
-        error: {}
-      })
-    }
-  })
-
-  const checkFilePath = function (req, res, next) {
-    const { filePath } = req.query
-    if (!filePath) {
-      res.status(400)
-      res.send({
-        success: false,
-        reason: 'No filePath provided (in query string)'
-      })
-    } else if (filePath.includes('..')) {
-      res.status(403)
-      res.send({
-        success: false,
-        reason: 'FilePath seems to be traversing using "..", that\'s not allowed here'
-      })
-    } else if (filePath.includes('node_modules')) {
-      res.status(403)
-      res.send({
-        success: false,
-        reason: 'FilePath seems to be inside node_modules, that\'s not allowed here'
-      })
-    } else {
-      next()
-    }
+    } catch (e) {}
   }
-
-  editorRouter.get('/file-contents', [checkFilePath], async (req, res) => {
-    const { filePath } = req.query
-
-    try {
-      const contents = await fsp.readFile(path.join(projectDir, filePath), 'utf8')
-
-      res.send({ success: true, contents })
-    } catch (e) {
-      console.error(e)
-      res.status(500)
-      res.send({
-        success: false,
-        error: {
-          message: e.message
-        }
-      })
-    }
-  })
-
-  editorRouter.post('/file-contents', [checkFilePath], async (req, res) => {
-    const { filePath } = req.query
-    const { contents, mode } = req.body
-    const fullPath = path.join(projectDir, filePath)
-
-    if (mode === 'write') {
-      await fsp.writeFile(fullPath, contents)
-      res.send({ success: true })
-    } else if (mode === 'delete') {
-      await fse.remove(fullPath)
-      res.send({ success: true })
-    }
-  })
-
-  routesApi.serveDirectory(`${contextPath}/monaco-editor/min`, path.join(packageDir, 'node_modules', 'monaco-editor', 'min'))
-  routesApi.serveDirectory(`${contextPath}/monaco-editor/min`, path.join(projectDir, 'node_modules', 'monaco-editor', 'min'))
-  routesApi.serveDirectory(`${contextPath}/monaco-editor/min-maps`, path.join(packageDir, 'node_modules', 'monaco-editor', 'min-maps'))
-  routesApi.serveDirectory(`${contextPath}/monaco-editor/min-maps`, path.join(projectDir, 'node_modules', 'monaco-editor', 'min-maps'))
 }
 
-module.exports = {
-  addRoutes
+async function addIfFileExistsAndCanBeEdited (files, label, relativeOrAbsolutePath, type) {
+  const relativePath = relativeOrAbsolutePath.startsWith('/') || relativeOrAbsolutePath.substring(1, 3) === ':\\' ? path.relative(projectDir, relativeOrAbsolutePath) : relativeOrAbsolutePath
+  if (relativePath.startsWith('node_modules') || relativePath.startsWith('.tmp')) {
+    return
+  }
+  const pathToCheck = path.join(projectDir, relativePath)
+  if (await fse.exists(pathToCheck)) {
+    files.push(fileDescriptor(label, relativePath, type))
+  }
 }
+
+editorRouter.get('/files-behind-url', async (req, res) => {
+  const { url } = req.query
+  if (!url) {
+    res.status(400).send('No URL provided.')
+    return
+  }
+  const view = await loadNunjucks(url)
+  if (view) {
+    const files = []
+    await addIfFileExistsAndCanBeEdited(files, 'page', view.path, 'NUNJUCKS')
+    const layoutMatch = view.src.match(/\{\s*%\s+extends\s+"([^"]+)"\s*%\s*}/)
+    if (layoutMatch) {
+      const njk = await loadNunjucks(layoutMatch[1])
+      if (njk) {
+        await addIfFileExistsAndCanBeEdited(files, 'layout', njk.path, 'NUNJUCKS')
+      }
+    }
+    await addIfFileExistsAndCanBeEdited(files, 'config', 'app/config.json', 'JSON')
+    await addIfFileExistsAndCanBeEdited(files, 'javascript', 'app/assets/javascripts/application.js', 'JS')
+    await addIfFileExistsAndCanBeEdited(files, 'scss', 'app/assets/sass/application.scss', 'SCSS')
+    await addIfFileExistsAndCanBeEdited(files, 'scss settings', 'app/assets/sass/settings.scss', 'SCSS')
+
+    res.send({
+      success: true,
+      files
+    })
+  } else {
+    res.send({
+      success: false,
+      error: {}
+    })
+  }
+})
+
+const checkFilePath = function (req, res, next) {
+  const { filePath } = req.query
+  if (!filePath) {
+    res.status(400)
+    res.send({
+      success: false,
+      reason: 'No filePath provided (in query string)'
+    })
+  } else if (filePath.includes('..')) {
+    res.status(403)
+    res.send({
+      success: false,
+      reason: 'FilePath seems to be traversing using "..", that\'s not allowed here'
+    })
+  } else if (filePath.includes('node_modules')) {
+    res.status(403)
+    res.send({
+      success: false,
+      reason: 'FilePath seems to be inside node_modules, that\'s not allowed here'
+    })
+  } else {
+    next()
+  }
+}
+
+editorRouter.get('/file-contents', [checkFilePath], async (req, res) => {
+  const { filePath } = req.query
+
+  try {
+    const contents = await fsp.readFile(path.join(projectDir, filePath), 'utf8')
+
+    res.send({ success: true, contents })
+  } catch (e) {
+    console.error(e)
+    res.status(500)
+    res.send({
+      success: false,
+      error: {
+        message: e.message
+      }
+    })
+  }
+})
+
+editorRouter.post('/file-contents', [checkFilePath], async (req, res) => {
+  const { filePath } = req.query
+  const { contents, mode } = req.body
+  const fullPath = path.join(projectDir, filePath)
+
+  if (mode === 'write') {
+    await fsp.writeFile(fullPath, contents)
+    res.send({ success: true })
+  } else if (mode === 'delete') {
+    await fse.remove(fullPath)
+    res.send({ success: true })
+  }
+})
+
+routesApi.serveDirectory(`${contextPath}/monaco-editor/min`, path.join(packageDir, 'node_modules', 'monaco-editor', 'min'))
+routesApi.serveDirectory(`${contextPath}/monaco-editor/min`, path.join(projectDir, 'node_modules', 'monaco-editor', 'min'))
+routesApi.serveDirectory(`${contextPath}/monaco-editor/min-maps`, path.join(packageDir, 'node_modules', 'monaco-editor', 'min-maps'))
+routesApi.serveDirectory(`${contextPath}/monaco-editor/min-maps`, path.join(projectDir, 'node_modules', 'monaco-editor', 'min-maps'))


### PR DESCRIPTION
I'm using (abusing) the filters config to add the router, I've also added a (rather over-engineered) message for those who still have the line in their kit.

To try this run:

`npm install github:x-govuk/edit-prototype-in-browser#no-setup-needed`

That can be run either in a prototype that's never had the setup line, in which case it should just add the editor; or in a prototype which has the setup line, in which case it will add the editor and a line to the kit startup explaining that you can remove the old setup line (and hopefully pointing you to the right file and line number).

*Note:* There are a lot of lines changed in this PR, that's because the whole `routes.js` file is no longer inside a function definition.  The diff when ignoring whitespace changes is *significantly* smaller.

The message display in ideal scenarios is:

```
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
                  You no longer to use need the `addRoutes` line.
           This line used to be needed to enable the in-browser editor.

     It looks like the line you need to remove is in app/routes.js on line 10.
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
```

### A really standard message when there's space to display it properly

<img width="718" alt="Screenshot 2023-08-17 at 21 44 14" src="https://github.com/x-govuk/edit-prototype-in-browser/assets/1216162/29914c89-2728-4ff7-8f29-e5e477b0ecf8">

### The same standard message when there's not enough space to display it properly

<img width="533" alt="Screenshot 2023-08-17 at 21 44 28" src="https://github.com/x-govuk/edit-prototype-in-browser/assets/1216162/36f063b3-1350-4f3a-afc0-3ceaa193ce4e">

### A really long file name and line number when there's space to display it properly

<img width="883" alt="Screenshot 2023-08-17 at 21 51 23" src="https://github.com/x-govuk/edit-prototype-in-browser/assets/1216162/ea0daf3e-1431-4254-9092-67d7a188c5a7">

### A really long file name and line number when there's not enough space to display it properly

<img width="585" alt="Screenshot 2023-08-17 at 21 47 24" src="https://github.com/x-govuk/edit-prototype-in-browser/assets/1216162/f29b5918-a663-4e2b-97e6-06f633bb9819">